### PR TITLE
Added TRANSACTION_ISOLATION_LEVEL in AbstractDBSpecificConnectorConfig

### DIFF
--- a/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfig.java
@@ -45,6 +45,8 @@ public abstract class ConnectionConfig extends PluginConfig implements DatabaseC
   public static final String CONNECTION_ARGUMENTS = "connectionArguments";
   public static final String JDBC_PLUGIN_NAME = "jdbcPluginName";
   public static final String JDBC_PLUGIN_TYPE = "jdbc";
+  public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
+  public static final String ROLE = "role";
 
   @Name(JDBC_PLUGIN_NAME)
   @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +

--- a/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/ConnectionConfig.java
@@ -46,7 +46,7 @@ public abstract class ConnectionConfig extends PluginConfig implements DatabaseC
   public static final String JDBC_PLUGIN_NAME = "jdbcPluginName";
   public static final String JDBC_PLUGIN_TYPE = "jdbc";
   public static final String TRANSACTION_ISOLATION_LEVEL = "transactionIsolationLevel";
-  public static final String ROLE = "role";
+
 
   @Name(JDBC_PLUGIN_NAME)
   @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +

--- a/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
@@ -208,7 +208,6 @@ public abstract class AbstractDBSpecificSourceConfig extends PluginConfig implem
   }
 
   public String getTransactionIsolationLevel() {
-    LOG.debug("Hi Krish Inside AbstractDBSpecificSourceConfig getTransactionIsolationLevel ");
     return null;
   }
 

--- a/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/config/AbstractDBSpecificSourceConfig.java
@@ -28,6 +28,8 @@ import io.cdap.plugin.common.Constants;
 import io.cdap.plugin.db.TransactionIsolationLevel;
 import io.cdap.plugin.db.connector.AbstractDBConnectorConfig;
 import io.cdap.plugin.db.source.AbstractDBSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -49,6 +51,7 @@ public abstract class AbstractDBSpecificSourceConfig extends PluginConfig implem
   public static final String DATABASE = "database";
   public static final String FETCH_SIZE = "fetchSize";
   public static final String DEFAULT_FETCH_SIZE = "1000";
+  public static final Logger LOG = LoggerFactory.getLogger(AbstractDBSpecificSourceConfig.class);
 
   @Name(Constants.Reference.REFERENCE_NAME)
   @Description(Constants.Reference.REFERENCE_NAME_DESCRIPTION)
@@ -205,6 +208,7 @@ public abstract class AbstractDBSpecificSourceConfig extends PluginConfig implem
   }
 
   public String getTransactionIsolationLevel() {
+    LOG.debug("Hi Krish Inside AbstractDBSpecificSourceConfig getTransactionIsolationLevel ");
     return null;
   }
 

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBConnectorConfig.java
@@ -117,7 +117,6 @@ public abstract class AbstractDBConnectorConfig extends PluginConfig implements 
   }
 
   public Map<String, String> getAdditionalArguments() {
-    LOG.debug("inside get Additional argument of AbstractDBConnectorConfig");
     return Collections.emptyMap();
   }
 

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBConnectorConfig.java
@@ -25,6 +25,8 @@ import io.cdap.cdap.api.plugin.PluginConfig;
 import io.cdap.plugin.common.KeyValueListParser;
 import io.cdap.plugin.common.db.DBConnectorProperties;
 import io.cdap.plugin.db.ConnectionConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,6 +38,8 @@ import javax.annotation.Nullable;
  *
  */
 public abstract class AbstractDBConnectorConfig extends PluginConfig implements DBConnectorProperties {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDBConnectorConfig.class);
 
   @Name(ConnectionConfig.JDBC_PLUGIN_NAME)
   @Description("Name of the JDBC driver to use. This is the value of the 'jdbcPluginName' key defined in the JSON " +
@@ -113,6 +117,7 @@ public abstract class AbstractDBConnectorConfig extends PluginConfig implements 
   }
 
   public Map<String, String> getAdditionalArguments() {
+    LOG.debug("inside get Additional argument of AbstractDBConnectorConfig");
     return Collections.emptyMap();
   }
 

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnector.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.lib.db.DBConfiguration;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -56,6 +58,7 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
   implements BatchConnector<LongWritable, T> {
 
   private final AbstractDBConnectorConfig config;
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDBSpecificConnector.class);
 
   protected AbstractDBSpecificConnector(AbstractDBConnectorConfig config) {
     super(config);
@@ -99,6 +102,7 @@ public abstract class AbstractDBSpecificConnector<T extends DBWritable> extends 
       tableQuery, null, false);
     connectionConfigAccessor.setConnectionArguments(Maps.fromProperties(config.getConnectionArgumentsProperties()));
     connectionConfigAccessor.getConfiguration().setInt(MRJobConfig.NUM_MAPS, 1);
+    LOG.debug("Moving inside AbstractDBConnectorConfig");
     Map<String, String> additionalArguments = config.getAdditionalArguments();
     for (Map.Entry<String, String> argument : additionalArguments.entrySet()) {
       connectionConfigAccessor.getConfiguration().set(argument.getKey(), argument.getValue());

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -43,7 +43,6 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   @Nullable
   protected Integer port;
 
-
   @Name(ConnectionConfig.TRANSACTION_ISOLATION_LEVEL)
   @Description("The transaction isolation level for the database session.")
   @Macro
@@ -66,7 +65,7 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
 
   public String getTransactionIsolationLevel() {
     if (transactionIsolationLevel == null) {
-      transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name();
+      return null;
     }
     return TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -31,8 +31,6 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnectorConfig {
 
-  private static final String ROLE_NORMAL = "normal";
-
   @Name(ConnectionConfig.HOST)
   @Description("Database host")
   @Macro

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -23,6 +23,7 @@ import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.TransactionIsolationLevel;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -61,6 +62,15 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
 
   public boolean canConnect() {
     return super.canConnect() && !containsMacro(ConnectionConfig.HOST) && !containsMacro(ConnectionConfig.PORT);
+  }
+
+  @Override
+  public Map<String, String> getAdditionalArguments() {
+    Map<String, String> additonalArguments = new HashMap<>();
+    if (getTransactionIsolationLevel() != null) {
+      additonalArguments.put(TransactionIsolationLevel.CONF_KEY, getTransactionIsolationLevel());
+    }
+    return additonalArguments;
   }
 
   public String getTransactionIsolationLevel() {

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -66,7 +66,7 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
 
   public String getTransactionIsolationLevel() {
     if (transactionIsolationLevel == null) {
-      transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_SERIALIZABLE.name();
+      transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name();
     }
     return TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -45,10 +45,6 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   @Nullable
   protected Integer port;
 
-  @Name(ConnectionConfig.ROLE)
-  @Description("Login role of the user when connecting to the database.")
-  @Nullable
-  protected String role;
 
   @Name(ConnectionConfig.TRANSACTION_ISOLATION_LEVEL)
   @Description("The transaction isolation level for the database session.")
@@ -70,15 +66,10 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
     return super.canConnect() && !containsMacro(ConnectionConfig.HOST) && !containsMacro(ConnectionConfig.PORT);
   }
 
-  public String getRole() {
-    return role == null ? "normal" : role;
-  }
-
   public String getTransactionIsolationLevel() {
     if (transactionIsolationLevel == null) {
       transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_SERIALIZABLE.name();
     }
-    return (!getRole().equals(ROLE_NORMAL)) ? TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name() :
-      TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
+    return TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }
 }

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -21,6 +21,8 @@ import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.plugin.db.ConnectionConfig;
 import io.cdap.plugin.db.TransactionIsolationLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,9 +34,11 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnectorConfig {
 
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractDBSpecificConnectorConfig.class);
   @Name(ConnectionConfig.HOST)
   @Description("Database host")
   @Macro
+
   @Nullable
   protected String host;
 
@@ -67,6 +71,7 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   @Override
   public Map<String, String> getAdditionalArguments() {
     Map<String, String> additonalArguments = new HashMap<>();
+    LOG.debug("inside get AdditionalArguemnts of AbstractDBSpecificConnectorConfig");
     if (getTransactionIsolationLevel() != null) {
       additonalArguments.put(TransactionIsolationLevel.CONF_KEY, getTransactionIsolationLevel());
     }
@@ -74,9 +79,11 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   }
 
   public String getTransactionIsolationLevel() {
+    LOG.debug("Hi Krish, INSIDE AbstractDBSpecificConnectorCOnfig getTransactionIsolationLevel");
     if (transactionIsolationLevel == null) {
       return null;
     }
     return TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }
 }
+

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -20,6 +20,7 @@ import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
 import io.cdap.plugin.db.ConnectionConfig;
+import io.cdap.plugin.db.TransactionIsolationLevel;
 
 import java.util.Collections;
 import java.util.Map;
@@ -29,6 +30,8 @@ import javax.annotation.Nullable;
  * An abstract DB Specific Connector config that those DB specific plugin config can inherit
  */
 public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnectorConfig {
+
+  private static final String ROLE_NORMAL = "normal";
 
   @Name(ConnectionConfig.HOST)
   @Description("Database host")
@@ -42,6 +45,17 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   @Nullable
   protected Integer port;
 
+  @Name(ConnectionConfig.ROLE)
+  @Description("Login role of the user when connecting to the database.")
+  @Nullable
+  protected String role;
+
+  @Name(ConnectionConfig.TRANSACTION_ISOLATION_LEVEL)
+  @Description("The transaction isolation level for the database session.")
+  @Macro
+  @Nullable
+  protected String transactionIsolationLevel;
+
   public String getHost() {
     return host;
   }
@@ -54,5 +68,17 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
 
   public boolean canConnect() {
     return super.canConnect() && !containsMacro(ConnectionConfig.HOST) && !containsMacro(ConnectionConfig.PORT);
+  }
+
+  public String getRole() {
+    return role == null ? "normal" : role;
+  }
+
+  public String getTransactionIsolationLevel() {
+    if (transactionIsolationLevel == null) {
+      transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_SERIALIZABLE.name();
+    }
+    return (!getRole().equals(ROLE_NORMAL)) ? TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name() :
+      TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }
 }

--- a/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
+++ b/database-commons/src/main/java/io/cdap/plugin/db/connector/AbstractDBSpecificConnectorConfig.java
@@ -79,7 +79,6 @@ public abstract class AbstractDBSpecificConnectorConfig extends AbstractDBConnec
   }
 
   public String getTransactionIsolationLevel() {
-    LOG.debug("Hi Krish, INSIDE AbstractDBSpecificConnectorCOnfig getTransactionIsolationLevel");
     if (transactionIsolationLevel == null) {
       return null;
     }

--- a/mysql-plugin/docs/MySQL-connector.md
+++ b/mysql-plugin/docs/MySQL-connector.md
@@ -22,6 +22,13 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable
+  reads and phantom reads are possible.
+
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.
 This is a semicolon-separated list of key-value pairs, where each pair is separated by a equals '=' and specifies

--- a/mysql-plugin/docs/MySQL-connector.md
+++ b/mysql-plugin/docs/MySQL-connector.md
@@ -26,8 +26,7 @@ authentication. Optional for databases that do not require authentication.
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
 - TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
-- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable
-  reads and phantom reads are possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
 
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver, as connection arguments, for JDBC drivers that may need additional configurations.

--- a/mysql-plugin/docs/MySQL-connector.md
+++ b/mysql-plugin/docs/MySQL-connector.md
@@ -24,7 +24,7 @@ authentication. Optional for databases that do not require authentication.
 
 **Transaction Isolation Level** The transaction isolation level of the databse connection
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
-- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
 - TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
 

--- a/mysql-plugin/docs/Mysql-batchsink.md
+++ b/mysql-plugin/docs/Mysql-batchsink.md
@@ -39,6 +39,13 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable
+reads and phantom reads are possible.
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/mysql-plugin/docs/Mysql-batchsink.md
+++ b/mysql-plugin/docs/Mysql-batchsink.md
@@ -41,7 +41,7 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Transaction Isolation Level** The transaction isolation level of the databse connection
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
-- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
 - TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
 

--- a/mysql-plugin/docs/Mysql-batchsink.md
+++ b/mysql-plugin/docs/Mysql-batchsink.md
@@ -43,8 +43,7 @@ You also can use the macro function ${conn(connection-name)}.
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
 - TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
-- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable
-reads and phantom reads are possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
 
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.

--- a/mysql-plugin/docs/Mysql-batchsource.md
+++ b/mysql-plugin/docs/Mysql-batchsource.md
@@ -49,6 +49,13 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable
+  reads and phantom reads are possible.
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/mysql-plugin/docs/Mysql-batchsource.md
+++ b/mysql-plugin/docs/Mysql-batchsource.md
@@ -51,7 +51,7 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Transaction Isolation Level** The transaction isolation level of the databse connection
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
-- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
 - TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
 

--- a/mysql-plugin/docs/Mysql-batchsource.md
+++ b/mysql-plugin/docs/Mysql-batchsource.md
@@ -53,8 +53,7 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
 - TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
-- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable
-  reads and phantom reads are possible.
+- TRANSACTION_READ_UNCOMMITTED: Allows dirty reads (reading uncommitted changes from other transactions). Non-repeatable reads and phantom reads are possible.
 
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
@@ -198,6 +198,11 @@ public class MysqlSource extends AbstractDBSource<MysqlSource.MysqlSourceConfig>
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
       super.validate(collector);

--- a/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/io/cdap/plugin/mysql/MysqlSource.java
@@ -205,6 +205,7 @@ public class MysqlSource extends AbstractDBSource<MysqlSource.MysqlSourceConfig>
     @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
+      connection.getAdditionalArguments();
       super.validate(collector);
     }
 

--- a/mysql-plugin/widgets/MySQL-connector.json
+++ b/mysql-plugin/widgets/MySQL-connector.json
@@ -30,6 +30,43 @@
           "widget-attributes": {
             "default": "3306"
           }
+        },
+        {
+          "label": "Role",
+          "name": "role",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "normal",
+            "options": [
+              {
+                "id": "normal",
+                "label": "Normal"
+              },
+              {
+                "id": "sysdba",
+                "label": "SYSDBA"
+              },
+              {
+                "id": "sysoper",
+                "label": "SYSOPER"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
         }
       ]
     },

--- a/mysql-plugin/widgets/MySQL-connector.json
+++ b/mysql-plugin/widgets/MySQL-connector.json
@@ -32,29 +32,6 @@
           }
         },
         {
-          "label": "Role",
-          "name": "role",
-          "widget-type": "radio-group",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "normal",
-            "options": [
-              {
-                "id": "normal",
-                "label": "Normal"
-              },
-              {
-                "id": "sysdba",
-                "label": "SYSDBA"
-              },
-              {
-                "id": "sysoper",
-                "label": "SYSOPER"
-              }
-            ]
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Transaction Isolation Level",
           "name": "transactionIsolationLevel",

--- a/mysql-plugin/widgets/Mysql-batchsink.json
+++ b/mysql-plugin/widgets/Mysql-batchsink.json
@@ -66,6 +66,43 @@
           "name": "password"
         },
         {
+          "label": "Role",
+          "name": "role",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "normal",
+            "options": [
+              {
+                "id": "normal",
+                "label": "Normal"
+              },
+              {
+                "id": "sysdba",
+                "label": "SYSDBA"
+              },
+              {
+                "id": "sysoper",
+                "label": "SYSOPER"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",

--- a/mysql-plugin/widgets/Mysql-batchsink.json
+++ b/mysql-plugin/widgets/Mysql-batchsink.json
@@ -245,6 +245,18 @@
   "outputs": [],
   "filters": [
     {
+      "name": "showIsolationLevels",
+      "condition": {
+        "expression": "role == 'normal'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
+        }
+      ]
+    },
+    {
       "name": "showConnectionProperties ",
       "condition": {
         "expression": "useConnection == false"
@@ -261,6 +273,10 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/mysql-plugin/widgets/Mysql-batchsink.json
+++ b/mysql-plugin/widgets/Mysql-batchsink.json
@@ -66,29 +66,6 @@
           "name": "password"
         },
         {
-          "label": "Role",
-          "name": "role",
-          "widget-type": "radio-group",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "normal",
-            "options": [
-              {
-                "id": "normal",
-                "label": "Normal"
-              },
-              {
-                "id": "sysdba",
-                "label": "SYSDBA"
-              },
-              {
-                "id": "sysoper",
-                "label": "SYSOPER"
-              }
-            ]
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Transaction Isolation Level",
           "name": "transactionIsolationLevel",
@@ -244,18 +221,6 @@
   ],
   "outputs": [],
   "filters": [
-    {
-      "name": "showIsolationLevels",
-      "condition": {
-        "expression": "role == 'normal'"
-      },
-      "show": [
-        {
-          "type": "property",
-          "name": "transactionIsolationLevel"
-        }
-      ]
-    },
     {
       "name": "showConnectionProperties ",
       "condition": {

--- a/mysql-plugin/widgets/Mysql-batchsource.json
+++ b/mysql-plugin/widgets/Mysql-batchsource.json
@@ -66,6 +66,43 @@
           "name": "password"
         },
         {
+          "label": "Role",
+          "name": "role",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "normal",
+            "options": [
+              {
+                "id": "normal",
+                "label": "Normal"
+              },
+              {
+                "id": "sysdba",
+                "label": "SYSDBA"
+              },
+              {
+                "id": "sysoper",
+                "label": "SYSOPER"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_UNCOMMITTED",
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",

--- a/mysql-plugin/widgets/Mysql-batchsource.json
+++ b/mysql-plugin/widgets/Mysql-batchsource.json
@@ -297,6 +297,18 @@
   ],
   "filters": [
     {
+      "name": "showIsolationLevels",
+      "condition": {
+        "expression": "role == 'normal'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
+        }
+      ]
+    },
+    {
       "name": "showConnectionProperties ",
       "condition": {
         "expression": "useConnection == false"
@@ -313,6 +325,10 @@
         {
           "type": "property",
           "name": "password"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/mysql-plugin/widgets/Mysql-batchsource.json
+++ b/mysql-plugin/widgets/Mysql-batchsource.json
@@ -66,29 +66,6 @@
           "name": "password"
         },
         {
-          "label": "Role",
-          "name": "role",
-          "widget-type": "radio-group",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "normal",
-            "options": [
-              {
-                "id": "normal",
-                "label": "Normal"
-              },
-              {
-                "id": "sysdba",
-                "label": "SYSDBA"
-              },
-              {
-                "id": "sysoper",
-                "label": "SYSOPER"
-              }
-            ]
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Transaction Isolation Level",
           "name": "transactionIsolationLevel",
@@ -296,18 +273,6 @@
     }
   ],
   "filters": [
-    {
-      "name": "showIsolationLevels",
-      "condition": {
-        "expression": "role == 'normal'"
-      },
-      "show": [
-        {
-          "type": "property",
-          "name": "transactionIsolationLevel"
-        }
-      ]
-    },
     {
       "name": "showConnectionProperties ",
       "condition": {

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -118,6 +118,18 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     return prop;
   }
 
+  public String getTransactionIsolationLevel() {
+    //if null default to the highest isolation level possible
+    if (transactionIsolationLevel == null) {
+      transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_SERIALIZABLE.name();
+    }
+    //To solve the problem of ORA-08178: illegal SERIALIZABLE clause specified for user INTERNAL
+    //This ensures that the role is mapped to the right serialization level, even w/ incorrect user input
+    //if role is SYSDBA or SYSOP it will map to read_committed. else serialized
+    return (!getRole().equals(ROLE_NORMAL)) ? TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name() :
+      TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
+  }
+
   @Override
   public Map<String, String> getAdditionalArguments() {
     Map<String, String> additonalArguments = new HashMap<>();

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -81,12 +81,6 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
   @Macro
   private String database;
 
-  @Name(OracleConstants.TRANSACTION_ISOLATION_LEVEL)
-  @Description("The transaction isolation level for the database session.")
-  @Macro
-  @Nullable
-  private String transactionIsolationLevel;
-
   @Name(OracleConstants.USE_SSL)
   @Description("Turns on SSL encryption. Connection will fail if SSL is not available")
   @Nullable
@@ -122,18 +116,6 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     prop.put(TIME_ZONE_AS_REGION_PROPERTY, "false");
     prop.put(INTERNAL_LOGON_PROPERTY, getRole());
     return prop;
-  }
-
-  public String getTransactionIsolationLevel() {
-    //if null default to the highest isolation level possible
-    if (transactionIsolationLevel == null) {
-      transactionIsolationLevel = TransactionIsolationLevel.Level.TRANSACTION_SERIALIZABLE.name();
-    }
-    //To solve the problem of ORA-08178: illegal SERIALIZABLE clause specified for user INTERNAL
-    //This ensures that the role is mapped to the right serialization level, even w/ incorrect user input
-    //if role is SYSDBA or SYSOP it will map to read_committed. else serialized
-    return (!getRole().equals(ROLE_NORMAL)) ? TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name() :
-            TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
   }
 
   @Override

--- a/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
+++ b/oracle-plugin/src/main/java/io/cdap/plugin/oracle/OracleConnectorConfig.java
@@ -118,6 +118,7 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     return prop;
   }
 
+  @Override
   public String getTransactionIsolationLevel() {
     //if null default to the highest isolation level possible
     if (transactionIsolationLevel == null) {
@@ -128,15 +129,6 @@ public class OracleConnectorConfig extends AbstractDBSpecificConnectorConfig {
     //if role is SYSDBA or SYSOP it will map to read_committed. else serialized
     return (!getRole().equals(ROLE_NORMAL)) ? TransactionIsolationLevel.Level.TRANSACTION_READ_COMMITTED.name() :
       TransactionIsolationLevel.Level.valueOf(transactionIsolationLevel).name();
-  }
-
-  @Override
-  public Map<String, String> getAdditionalArguments() {
-    Map<String, String> additonalArguments = new HashMap<>();
-    if (getTransactionIsolationLevel() != null) {
-      additonalArguments.put(TransactionIsolationLevel.CONF_KEY, getTransactionIsolationLevel());
-    }
-    return additonalArguments;
   }
 
   @Override

--- a/postgresql-plugin/docs/PostgreSQL-connector.md
+++ b/postgresql-plugin/docs/PostgreSQL-connector.md
@@ -22,6 +22,11 @@ authentication. Optional for databases that do not require authentication.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+
 **Database:** The name of the database to connect to.
 
 **Connection Arguments:** A list of arbitrary string tag/value pairs as connection arguments. These arguments

--- a/postgresql-plugin/docs/PostgreSQL-connector.md
+++ b/postgresql-plugin/docs/PostgreSQL-connector.md
@@ -24,7 +24,7 @@ authentication. Optional for databases that do not require authentication.
 
 **Transaction Isolation Level** The transaction isolation level of the databse connection
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
-- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
 
 **Database:** The name of the database to connect to.

--- a/postgresql-plugin/docs/Postgres-batchsink.md
+++ b/postgresql-plugin/docs/Postgres-batchsink.md
@@ -41,7 +41,7 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Transaction Isolation Level** The transaction isolation level of the databse connection
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
-- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
 
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments

--- a/postgresql-plugin/docs/Postgres-batchsink.md
+++ b/postgresql-plugin/docs/Postgres-batchsink.md
@@ -39,6 +39,11 @@ You also can use the macro function ${conn(connection-name)}.
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/postgresql-plugin/docs/Postgres-batchsource.md
+++ b/postgresql-plugin/docs/Postgres-batchsource.md
@@ -51,7 +51,7 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Transaction Isolation Level** The transaction isolation level of the databse connection
 - TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
-- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_SERIALIZABLE: No dirty reads. Non-repeatable and phantom reads are prevented.
 - TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
 
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments

--- a/postgresql-plugin/docs/Postgres-batchsource.md
+++ b/postgresql-plugin/docs/Postgres-batchsource.md
@@ -49,6 +49,11 @@ For example, 'SELECT MIN(id),MAX(id) FROM table'. Not required if numSplits is s
 
 **Password:** Password to use to connect to the specified database.
 
+**Transaction Isolation Level** The transaction isolation level of the databse connection
+- TRANSACTION_READ_COMMITTED: No dirty reads. Non-repeatable reads and phantom reads are possible.
+- TRANSACTION_SERIALIZABLE (default): No dirty reads. Non-repeatable and phantom reads are prevented.
+- TRANSACTION_REPEATABLE_READ: No dirty reads. Prevents non-repeatable reads, but phantom reads are still possible.
+
 **Connection Arguments:** A list of arbitrary string key/value pairs as connection arguments. These arguments
 will be passed to the JDBC driver as connection arguments for JDBC drivers that may need additional configurations.
 

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnectorConfig.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresConnectorConfig.java
@@ -19,6 +19,7 @@ package io.cdap.plugin.postgres;
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Macro;
 import io.cdap.cdap.api.annotation.Name;
+import io.cdap.plugin.db.TransactionIsolationLevel;
 import io.cdap.plugin.db.connector.AbstractDBSpecificConnectorConfig;
 
 /**

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
@@ -36,6 +36,8 @@ import io.cdap.plugin.db.config.AbstractDBSpecificSourceConfig;
 import io.cdap.plugin.db.source.AbstractDBSource;
 import io.cdap.plugin.util.DBUtils;
 import org.apache.hadoop.mapreduce.lib.db.DBWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -49,6 +51,8 @@ import javax.annotation.Nullable;
   " Outputs one record for each row returned by the query.")
 @Metadata(properties = {@MetadataProperty(key = Connector.PLUGIN_TYPE, value = PostgresConnector.NAME)})
 public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSourceConfig> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PostgresSource.class);
 
   private final PostgresSourceConfig postgresSourceConfig;
 
@@ -144,8 +148,15 @@ public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSour
     }
 
     @Override
+    public String getTransactionIsolationLevel() {
+      return connection.getTransactionIsolationLevel();
+    }
+
+    @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
+      LOG.debug("Hi Krish, transaction level is: {}", connection.getTransactionIsolationLevel());
+      connection.getAdditionalArguments();
       super.validate(collector);
     }
 

--- a/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
+++ b/postgresql-plugin/src/main/java/io/cdap/plugin/postgres/PostgresSource.java
@@ -155,7 +155,6 @@ public class PostgresSource extends AbstractDBSource<PostgresSource.PostgresSour
     @Override
     public void validate(FailureCollector collector) {
       ConfigUtil.validateConnection(this, useConnection, connection, collector);
-      LOG.debug("Hi Krish, transaction level is: {}", connection.getTransactionIsolationLevel());
       connection.getAdditionalArguments();
       super.validate(collector);
     }

--- a/postgresql-plugin/widgets/PostgreSQL-connector.json
+++ b/postgresql-plugin/widgets/PostgreSQL-connector.json
@@ -32,6 +32,42 @@
           }
         },
         {
+          "label": "Role",
+          "name": "role",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "normal",
+            "options": [
+              {
+                "id": "normal",
+                "label": "Normal"
+              },
+              {
+                "id": "sysdba",
+                "label": "SYSDBA"
+              },
+              {
+                "id": "sysoper",
+                "label": "SYSOPER"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "textbox",
           "label": "Database",
           "name": "database"

--- a/postgresql-plugin/widgets/PostgreSQL-connector.json
+++ b/postgresql-plugin/widgets/PostgreSQL-connector.json
@@ -32,29 +32,6 @@
           }
         },
         {
-          "label": "Role",
-          "name": "role",
-          "widget-type": "radio-group",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "normal",
-            "options": [
-              {
-                "id": "normal",
-                "label": "Normal"
-              },
-              {
-                "id": "sysdba",
-                "label": "SYSDBA"
-              },
-              {
-                "id": "sysoper",
-                "label": "SYSOPER"
-              }
-            ]
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Transaction Isolation Level",
           "name": "transactionIsolationLevel",

--- a/postgresql-plugin/widgets/Postgres-batchsink.json
+++ b/postgresql-plugin/widgets/Postgres-batchsink.json
@@ -66,6 +66,42 @@
           "name": "password"
         },
         {
+          "label": "Role",
+          "name": "role",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "normal",
+            "options": [
+              {
+                "id": "normal",
+                "label": "Normal"
+              },
+              {
+                "id": "sysdba",
+                "label": "SYSDBA"
+              },
+              {
+                "id": "sysoper",
+                "label": "SYSOPER"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -161,6 +197,18 @@
   "outputs": [],
   "filters": [
     {
+      "name": "showIsolationLevels",
+      "condition": {
+        "expression": "role == 'normal'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
+        }
+      ]
+    },
+    {
       "name": "showConnectionProperties ",
       "condition": {
         "expression": "useConnection == false"
@@ -185,6 +233,14 @@
         {
           "type": "property",
           "name": "port"
+        },
+        {
+          "type": "property",
+          "name": "role"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/postgresql-plugin/widgets/Postgres-batchsink.json
+++ b/postgresql-plugin/widgets/Postgres-batchsink.json
@@ -66,29 +66,6 @@
           "name": "password"
         },
         {
-          "label": "Role",
-          "name": "role",
-          "widget-type": "radio-group",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "normal",
-            "options": [
-              {
-                "id": "normal",
-                "label": "Normal"
-              },
-              {
-                "id": "sysdba",
-                "label": "SYSDBA"
-              },
-              {
-                "id": "sysoper",
-                "label": "SYSOPER"
-              }
-            ]
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Transaction Isolation Level",
           "name": "transactionIsolationLevel",
@@ -197,18 +174,6 @@
   "outputs": [],
   "filters": [
     {
-      "name": "showIsolationLevels",
-      "condition": {
-        "expression": "role == 'normal'"
-      },
-      "show": [
-        {
-          "type": "property",
-          "name": "transactionIsolationLevel"
-        }
-      ]
-    },
-    {
       "name": "showConnectionProperties ",
       "condition": {
         "expression": "useConnection == false"
@@ -233,10 +198,6 @@
         {
           "type": "property",
           "name": "port"
-        },
-        {
-          "type": "property",
-          "name": "role"
         },
         {
           "type": "property",

--- a/postgresql-plugin/widgets/Postgres-batchsource.json
+++ b/postgresql-plugin/widgets/Postgres-batchsource.json
@@ -66,6 +66,42 @@
           "name": "password"
         },
         {
+          "label": "Role",
+          "name": "role",
+          "widget-type": "radio-group",
+          "widget-attributes": {
+            "layout": "inline",
+            "default": "normal",
+            "options": [
+              {
+                "id": "normal",
+                "label": "Normal"
+              },
+              {
+                "id": "sysdba",
+                "label": "SYSDBA"
+              },
+              {
+                "id": "sysoper",
+                "label": "SYSOPER"
+              }
+            ]
+          }
+        },
+        {
+          "widget-type": "select",
+          "label": "Transaction Isolation Level",
+          "name": "transactionIsolationLevel",
+          "widget-attributes": {
+            "values": [
+              "TRANSACTION_READ_COMMITTED",
+              "TRANSACTION_REPEATABLE_READ",
+              "TRANSACTION_SERIALIZABLE"
+            ],
+            "default": "TRANSACTION_SERIALIZABLE"
+          }
+        },
+        {
           "widget-type": "keyvalue",
           "label": "Connection Arguments",
           "name": "connectionArguments",
@@ -181,6 +217,18 @@
   ],
   "filters": [
     {
+      "name": "showIsolationLevels",
+      "condition": {
+        "expression": "role == 'normal'"
+      },
+      "show": [
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
+        }
+      ]
+    },
+    {
       "name": "showConnectionProperties ",
       "condition": {
         "expression": "useConnection == false"
@@ -205,6 +253,14 @@
         {
           "type": "property",
           "name": "port"
+        },
+        {
+          "type": "property",
+          "name": "role"
+        },
+        {
+          "type": "property",
+          "name": "transactionIsolationLevel"
         },
         {
           "type": "property",

--- a/postgresql-plugin/widgets/Postgres-batchsource.json
+++ b/postgresql-plugin/widgets/Postgres-batchsource.json
@@ -66,29 +66,6 @@
           "name": "password"
         },
         {
-          "label": "Role",
-          "name": "role",
-          "widget-type": "radio-group",
-          "widget-attributes": {
-            "layout": "inline",
-            "default": "normal",
-            "options": [
-              {
-                "id": "normal",
-                "label": "Normal"
-              },
-              {
-                "id": "sysdba",
-                "label": "SYSDBA"
-              },
-              {
-                "id": "sysoper",
-                "label": "SYSOPER"
-              }
-            ]
-          }
-        },
-        {
           "widget-type": "select",
           "label": "Transaction Isolation Level",
           "name": "transactionIsolationLevel",
@@ -217,18 +194,6 @@
   ],
   "filters": [
     {
-      "name": "showIsolationLevels",
-      "condition": {
-        "expression": "role == 'normal'"
-      },
-      "show": [
-        {
-          "type": "property",
-          "name": "transactionIsolationLevel"
-        }
-      ]
-    },
-    {
       "name": "showConnectionProperties ",
       "condition": {
         "expression": "useConnection == false"
@@ -253,10 +218,6 @@
         {
           "type": "property",
           "name": "port"
-        },
-        {
-          "type": "property",
-          "name": "role"
         },
         {
           "type": "property",


### PR DESCRIPTION
Added support for specifying the transaction isolation level in database plugins by introducing a new optional property "transactionIsolationLevel" in the AbstractDBSpecificConnectorConfig class — the parent class for MySQL, PostgreSQL, and Oracle connector configurations.

![Screenshot from 2025-04-11 15-12-03](https://github.com/user-attachments/assets/94585d4c-22df-4541-9860-43a691eb1075)

